### PR TITLE
Fix not used error (-Werror=unused-variable)

### DIFF
--- a/include/heap.h
+++ b/include/heap.h
@@ -39,7 +39,7 @@ typedef struct {
     bin_t *bins[BIN_COUNT];
 } heap_t;
 
-static uint overhead = sizeof(footer_t) + sizeof(node_t);
+static const uint overhead = sizeof(footer_t) + sizeof(node_t);
 
 void init_heap(heap_t *heap, long start);
 

--- a/llist.c
+++ b/llist.c
@@ -4,8 +4,6 @@ void add_node(bin_t *bin, node_t* node) {
     node->next = NULL;
     node->prev = NULL;
 
-    node_t *temp = bin->head;
-
     if (bin->head == NULL) {
         bin->head = node;
         return;


### PR DESCRIPTION
Fix not used error.

This happens when it compiles with `-Werror=unused-variable`.
ex) `gcc -O3 llist.c heap.c main.c -o heap_test -Werror=unused-variable`